### PR TITLE
Upgrade aws sdk to v3

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,0 @@
-require "bundler/gem_tasks"
-

--- a/kumo_ki.gemspec
+++ b/kumo_ki.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.40'

--- a/kumo_ki.gemspec
+++ b/kumo_ki.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 0.40'
 
-  spec.add_runtime_dependency 'aws-sdk', '~> 2'
+  spec.add_runtime_dependency 'aws-sdk-kms', '~> 1'
 end

--- a/lib/kumo_ki.rb
+++ b/lib/kumo_ki.rb
@@ -1,6 +1,6 @@
 require 'kumo_ki/version'
 require 'kumo_ki/errors'
-require 'aws-sdk'
+require 'aws-sdk-kms'
 require 'base64'
 
 module KumoKi

--- a/lib/kumo_ki/version.rb
+++ b/lib/kumo_ki/version.rb
@@ -1,3 +1,3 @@
 module KumoKi
-  VERSION = "1.1.1"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
Resolves issue #5 and enables Redbubble monolith to upgrade it's AWS SDK to v3